### PR TITLE
Allow streamer names with special characters

### DIFF
--- a/TwitchArchiverWPF/AddStreamerDialog.xaml.cs
+++ b/TwitchArchiverWPF/AddStreamerDialog.xaml.cs
@@ -112,7 +112,7 @@ namespace TwitchArchiverWPF
                         }
                         catch { }
                     }
-                    if (profileResponse.data.user.displayName != null && profileResponse.data.user.displayName.All(char.IsLetterOrDigit))
+                    if (profileResponse.data.user.displayName != null)
                         streamerName = profileResponse.data.user.displayName;
                 }
             }


### PR DESCRIPTION
Some streamers are using characters like underscores or exclamation marks in their streamer name. Without this change the live status for those streamers will not be detected correctly. (Should that display name really be part of that request?)

This does however present an issue if a streamer uses a question mark in their display name as that is not a valid character for a windows directory name.